### PR TITLE
Changes to allow for Rapid Advancement of Gigantism defect

### DIFF
--- a/Colors.xml
+++ b/Colors.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<colors>
+  <shaders>
+    <shader Name="gigantic" Type="alternation" Colors="w-w-w" ShowInPicker="true" />
+  </shaders>
+</colors>

--- a/Gigantism.cs
+++ b/Gigantism.cs
@@ -7,9 +7,9 @@ using XRL.World.Parts.Mutation;
 namespace XRL.World.Parts.Mutation
 {
     [Serializable]
-    public class Gigantism : BaseDefaultEquipmentMutation
+    public class GigantismPlus : BaseDefaultEquipmentMutation
     {
-        public Gigantism()
+        public GigantismPlus()
         {
             DisplayName = "Gigantism ({{r|D}})";
             base.Type = "Physical";

--- a/ModifierAdjustments.cs
+++ b/ModifierAdjustments.cs
@@ -16,8 +16,8 @@ namespace Mods.GigantismPlus
             // Option Value 2 is "Everyone"
             // Option Value 1 is "Gigantic (D) players"
             // Everyone || (Gigantic && player is Gigantic)
-            bool ShouldDerarify = Options.SelectGiganticDerarification == 2 || (Options.SelectGiganticDerarification == 1 && player.HasPart("Gigantism"));
-            bool ShouldGiganticTinkerable = Options.SelectGiganticTinkering == 2 || (Options.SelectGiganticTinkering == 1 && player.HasPart("Gigantism"));
+            bool ShouldDerarify = Options.SelectGiganticDerarification == 2 || (Options.SelectGiganticDerarification == 1 && player.HasPart("GigantismPlus"));
+            bool ShouldGiganticTinkerable = Options.SelectGiganticTinkering == 2 || (Options.SelectGiganticTinkering == 1 && player.HasPart("GigantismPlus"));
             
             // find the gigantic modifier ModEntry in the ModList
             foreach (ModEntry mod in ModificationFactory.ModList)

--- a/Mods.xml
+++ b/Mods.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <mods>
-  <mod Part="ModGigantic" TinkerTier="3" Load="Merge"/>
+  <mod Part="ModGigantic" TinkerTier="3" TinkerDisplayName="gigantic" Load="Merge"/>
 </mods>

--- a/Mutations.xml
+++ b/Mutations.xml
@@ -1,5 +1,5 @@
 <mutations>
-  <category Name="PhysicalDefects">
-    <mutation Name="Gigantism" Cost="-5" MaxSelected="1" Class="Gigantism" BearerDescription="those who are gigantic" Tile="gigantism.png" />
+  <category Name="PhysicalDefects" Load="merge">
+    <mutation Name="GigantismPlus" Cost="-5" MaxSelected="1" Class="GigantismPlus" BearerDescription="those who are gigantic" Tile="gigantism.png" />
   </category>
 </mutations>

--- a/Options.xml
+++ b/Options.xml
@@ -1,22 +1,67 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <options>
-  <option ID="Option_GigantismPlus_EnableGiganticStartingGear"
-    DisplayText="Gigantify starting equipment for Gigantic ({{r|D}}) players (requires new save)"
-    Category="Mods: Gigantism Plus"
-    Type="Checkbox" Default="Yes" />
-  <option ID="Option_GigantismPlus_EnableGiganticStartingGear_Grenades"
-    Requires="Option_GigantismPlus_EnableGiganticStartingGear==Yes"
-    DisplayText="Include starting grenades (requires new save)"
-    Category="Mods: Gigantism Plus"
-    Type="Checkbox" Default="No" />
-  <option ID="Option_GigantismPlus_SelectGiganticTinkering"
-    DisplayText="Allow tinkering of gigantic modifier for: (requires new save)"
-    Category="Mods: Gigantism Plus"
-    Type="Combo" Default="Gigantic ({{r|D}}) players"
-    Values="No one,Gigantic ({{r|D}}) players,Everyone" />
-  <option ID="Option_GigantismPlus_SelectGiganticDerarification"
-    DisplayText="Make gigantic items slightly more common for: (requires new save)"
-    Category="Mods: Gigantism Plus"
-    Type="Combo" Default="Gigantic ({{r|D}}) players"
-    Values="No one,Gigantic ({{r|D}}) players,Everyone" />
+	
+	<option 
+		ID="Option_GigantismPlus_EnableGiganticStartingGear"
+	    DisplayText="{{gigantic|Gigantify}} starting equipment for Gigantic ({{r|D}}) players ({{R|new save}})"
+	    Category="Mods: Gigantism Plus"
+	    Type="Checkbox" Default="Yes"
+	>
+		<helptext>
+			A {{gigantic|gigantic}} character would have {{w|gigantic}} equipment when they arrive in Qud.
+			Disabling this option will make for a more difficult start.
+		</helptext>
+	</option>
+	
+	<option 
+		ID="Option_GigantismPlus_EnableGiganticStartingGear_Grenades"
+	    Requires="Option_GigantismPlus_EnableGiganticStartingGear==Yes"
+	    DisplayText="Include starting grenades ({{R|new save}})"
+	    Category="Mods: Gigantism Plus"
+	    Type="Checkbox" Default="No"
+	>
+		<helptext>
+			The {{gigantic|gigantic}} modifier typically increases the radius of grenades which could represent a significant reduction in starting difficulty for characters who generate with several of them.
+		</helptext>
+	</option>
+
+	<option
+		ID="Option_GigantismPlus_EnableGigantismRapidAdvance"
+	    DisplayText="Make Gigantism ({{r|D}}) eligible for rapid advancement"
+	    Category="Mods: Gigantism Plus"
+	    Type="Checkbox" Default="Yes"
+	>
+		<helptext>
+			({{r|D}})efects aren't typically able to be leveled up and are excluded from rapid advancement by default.
+			When enabled, Gigantism ({{r|D}}) will be included in the list of physical mutations for this purpose.
+		</helptext>
+	</option>
+	
+	<option 
+		ID="Option_GigantismPlus_SelectGiganticTinkering"
+	    DisplayText="Allow tinkering of {{gigantic|gigantic}} modifier for: ({{R|new save}})"
+	    Category="Mods: Gigantism Plus"
+	    Type="Combo" Default="Gigantic ({{r|D}}) players"
+	    Values="No one,Gigantic ({{r|D}}) players,Everyone"
+	>
+		<helptext>
+			This makes the {{gigantic|gigantic}} modifier tinkerable, including the availability of the data disk for it.
+			Its tech tier has been adjusted up to 3 so that it will cost at least a {{b|3}} bit to tinker.
+			Tinker I is the required skill.
+		</helptext>
+	</option>
+	
+	<option 
+		ID="Option_GigantismPlus_SelectGiganticDerarification"
+	    DisplayText="Make {{gigantic|gigantic}} items slightly more common for: ({{R|new save}})"
+	    Category="Mods: Gigantism Plus"
+	    Type="Combo" Default="Gigantic ({{r|D}}) players"
+	    Values="No one,Gigantic ({{r|D}}) players,Everyone"
+	>
+		<helptext>
+			This makes {{gigantic|gigantic}} items a little less rare to find by adjusting their rarity from R2 to R.
+			Some examples of other mods with R rarity: {{spiked|Spiked}}, {{k|Nulling}}, and {{C|Radio Powered}}.
+		</helptext>
+	</option>
+	
 </options>

--- a/ParseOptions.cs
+++ b/ParseOptions.cs
@@ -23,8 +23,10 @@ namespace Mods.GigantismPlus
 		
         // I believe these might actually need a full reload and not just a new save to take effect.
         // TODO: make them reinitialise between new games if they don't already.
+        // - Rapid advancement option seems to work on the fly.
         public static bool EnableGiganticStartingGear => GetOption("Option_GigantismPlus_EnableGiganticStartingGear").EqualsNoCase("Yes");
         public static bool EnableGiganticStartingGear_Grenades => GetOption("Option_GigantismPlus_EnableGiganticStartingGear_Grenades").EqualsNoCase("Yes");
+        public static bool EnableGigantismRapidAdvance => GetOption("Option_GigantismPlus_EnableGigantismRapidAdvance").EqualsNoCase("Yes");
         public static int SelectGiganticTinkering => ParseSelectPlayer(GetOption("Option_GigantismPlus_SelectGiganticTinkering"));
         public static int SelectGiganticDerarification => ParseSelectPlayer(GetOption("Option_GigantismPlus_SelectGiganticDerarification"));
     

--- a/StartingGear.cs
+++ b/StartingGear.cs
@@ -10,7 +10,7 @@ namespace Mods.GigantismPlus
         public void mutate(GameObject player)
         {
             // Is the player Gigantic, and is the option to have gigantic starting gear set?
-            if (player.HasPart("Gigantism") && Options.EnableGiganticStartingGear)
+            if (player.HasPart("GigantismPlus") && Options.EnableGiganticStartingGear)
             {
                 // Cycle the player's inventory and equipped items.
                 foreach (GameObject item in player.GetInventoryAndEquipment())


### PR DESCRIPTION
This is a quick and dirty set of commits. I did them last night, and made a couple of adjustments this morning I haven't been able to fully test.

I was bumping into a conflict with the mod overwriting the vanilla Gigantism, so I've adjusted everything to be a "new" implementation called GigantismPlus that just has Gigantism as the display name.

If it doesn't work for whatever reason, I can probably give it a test and work it out this afternoon. Probably 6 or so hours from this request.